### PR TITLE
DefulatGrammar 추가 작업 완료

### DIFF
--- a/src/solver/domainGrammar.ml
+++ b/src/solver/domainGrammar.ml
@@ -10,6 +10,8 @@ open Ast
     this module will automatically set other appropriate prefix like "DOM1_" or "DOM2_".
 *)
 
+let emptyGrammarDef = GrammarDef ([])
+
 let generateDomainGrammarPrefix : string list -> string =
   fun strlist ->
   let k = ref 0 in

--- a/src/solver/domainGrammar.ml
+++ b/src/solver/domainGrammar.ml
@@ -1,0 +1,30 @@
+open Ast
+
+(*
+  Domain Grammar
+    Domain Grammar is the default grammar provided by SyGuS language 2.0 specification(2019/May/16) Appendix-B.
+    The specification shows six different domain grammars (LIA, NIA, LRA, NRA, BV, S).
+
+    For convenience, all domain grammars' non-terminal symbol's name will have a prefix "DOM0_".
+    If "DOM0_" is already used in question-defined grammar's non-terminal symbol, 
+    this module will automatically set other appropriate prefix like "DOM1_" or "DOM2_".
+*)
+
+let generateDomainGrammarPrefix : string list -> string =
+  fun strlist ->
+  let k = ref 0 in
+  let genPrefix () = "DOM" ^ (string_of_int (!k)) ^ "_" in
+  let rec iter : string -> string =
+    fun prefix ->
+      if StringMethods.isPrefixDuplicated prefix strlist
+      then (ignore (k := !k + 1); iter (genPrefix ()))
+      else prefix
+  in
+  iter (genPrefix ())
+
+let getDomainGrammarPrefix : Ast.cmd list -> string list -> string =
+  (* prohibit_list contains string which should not be used for Domain Grammar's prefix. *)
+  fun cmdlist additional_prohibit_list ->
+  let nontermList : string list = 
+    ListMethods.collectAppliedList TypeMethods.cmd_getsl cmdlist in
+  generateDomainGrammarPrefix (nontermList @ additional_prohibit_list)

--- a/src/solver/domainGrammar.ml
+++ b/src/solver/domainGrammar.ml
@@ -30,39 +30,56 @@ let getDomainGrammarPrefix : Ast.cmd list -> string list -> string =
   generateDomainGrammarPrefix (nontermList @ additional_prohibit_list)
 
 (* Common symbols and identifiers in Domain grammars (Terminal symbols only) *)
-let gen_id : string -> Ast.identifier = fun s -> SymbolIdentifier (Symbol s)
-let gen_short_sort : string -> Ast.sort = fun s -> Sort (SymbolIdentifier (Symbol s))
-let sortInt     : Ast.sort = gen_short_sort "Int"
-let sortBool    : Ast.sort = gen_short_sort "Bool"
-let sortReal    : Ast.sort = gen_short_sort "Real"
-let id_plus_op  : Ast.identifier = gen_id "+"
-let id_minus_op : Ast.identifier = gen_id "-"
-let id_mul_op   : Ast.identifier = gen_id "*"
-let id_div_op   : Ast.identifier = gen_id "/"
-let id_div      : Ast.identifier = gen_id "div"
-let id_mod      : Ast.identifier = gen_id "mod"
-let id_abs      : Ast.identifier = gen_id "abs"
-let id_ite      : Ast.identifier = gen_id "ite"
-let id_eq_op    : Ast.identifier = gen_id "="
-let id_gt_op    : Ast.identifier = gen_id ">"
-let id_ge_op    : Ast.identifier = gen_id ">="
-let id_lt_op    : Ast.identifier = gen_id "<"
-let id_le_op    : Ast.identifier = gen_id "<="
+let make_id : string -> Ast.identifier = fun s -> SymbolIdentifier (Symbol s)
+let make_short_sort : string -> Ast.sort = fun s -> Sort (SymbolIdentifier (Symbol s))
+let sortInt     : Ast.sort = make_short_sort "Int"
+let sortBool    : Ast.sort = make_short_sort "Bool"
+let sortReal    : Ast.sort = make_short_sort "Real"
+let sortString  : Ast.sort = make_short_sort "String"
+let id_plus_op  : Ast.identifier = make_id "+"
+let id_minus_op : Ast.identifier = make_id "-"
+let id_mul_op   : Ast.identifier = make_id "*"
+let id_div_op   : Ast.identifier = make_id "/"
+let id_div      : Ast.identifier = make_id "div"
+let id_mod      : Ast.identifier = make_id "mod"
+let id_abs      : Ast.identifier = make_id "abs"
+let id_ite      : Ast.identifier = make_id "ite"
+let id_eq_op    : Ast.identifier = make_id "="
+let id_gt_op    : Ast.identifier = make_id ">"
+let id_ge_op    : Ast.identifier = make_id ">="
+let id_lt_op    : Ast.identifier = make_id "<"
+let id_le_op    : Ast.identifier = make_id "<="
+
+(*
+  y_term design choice: Why they are declared globally, not locally.
+    'y_term' and 'y_cons' may have different 'sort's, 
+    and therefore in the two different logics they cannot be integrated.
+    However, in the basic grammar, 'y_pred' is always a Bool,
+    so I think it would be much more natural to share y_pred in two logic forms, such as 'SLIA'.
+*)
+let make_y_term : string -> (string -> Ast.symbol) = fun sym -> (fun prefix -> Symbol (prefix ^ sym))
+let make_y_term_int   = make_y_term "y_term_int"
+let make_y_term_real  = make_y_term "y_term_real"
+let make_y_term_bv32  = make_y_term "y_term_bv32"
+let make_y_term_string = make_y_term "y_term_string"
+let make_y_cons_int   = make_y_term "y_cons_int"
+let make_y_cons_real  = make_y_term "y_cons_real"
+let make_y_pred_bool  = make_y_term "y_pred_bool"
 
 (* only available with identifier list arguments. *)
-let gen_bfidentifierterms : Ast.identifier list -> Ast.bf_term = 
+let make_bfidentifierterms : Ast.identifier list -> Ast.bf_term = 
   fun idlist ->
   match idlist with
   | [id1] -> BfIdentifier id1
   | id1 :: t -> BfIdentifierTerms (id1, List.map (fun id -> BfIdentifier id) t)
-  | _ -> invalid_arg "DomainGrammar.gen_bfidentifierterms needs one or more elements in argument list."
+  | _ -> invalid_arg "DomainGrammar.make_bfidentifierterms needs one or more elements in argument list."
 
 (* It cannot be used for general purposes. This generates (GTBfTerm (bf_term) : gterm) *)
-let gen_gtbfterm : Ast.identifier list -> Ast.gterm =
+let make_gtbfterm : Ast.identifier list -> Ast.gterm =
   fun idlist ->
   match idlist with
-  | h :: t -> GTBfTerm (gen_bfidentifierterms idlist)
-  | _ -> invalid_arg "DomainGrammar.gen_gtbfterm needs one or more elements in argument list."
+  | h :: t -> GTBfTerm (make_bfidentifierterms idlist)
+  | _ -> invalid_arg "DomainGrammar.make_gtbfterm needs one or more elements in argument list."
 
 
 
@@ -83,10 +100,9 @@ let gen_gtbfterm : Ast.identifier list -> Ast.gterm =
 
 let dom_LIA_grammardef : string -> Ast.grammar_def =
   fun prefix ->
-  let pre : string = prefix ^ "LIA_" in
-  let y_term : Ast.symbol = Symbol (pre ^ "y_term") in
-  let y_cons : Ast.symbol = Symbol (pre ^ "y_cons") in
-  let y_pred : Ast.symbol = Symbol (pre ^ "y_pred") in
+  let y_term : Ast.symbol = make_y_term_int prefix in
+  let y_cons : Ast.symbol = make_y_cons_int prefix in
+  let y_pred : Ast.symbol = make_y_pred_bool prefix in
   let id_y_term : Ast.identifier = SymbolIdentifier y_term in
   let id_y_cons : Ast.identifier = SymbolIdentifier y_cons in
   let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
@@ -102,15 +118,15 @@ let dom_LIA_grammardef : string -> Ast.grammar_def =
               [
                 GTBfTerm (BfIdentifier id_y_cons);
                 GTVariable sortInt;
-                gen_gtbfterm [id_minus_op; id_y_term];
-                gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_mul_op; id_y_cons; id_y_term];
-                gen_gtbfterm [id_mul_op; id_y_term; id_y_cons];
-                gen_gtbfterm [id_div; id_y_term; id_y_cons];
-                gen_gtbfterm [id_mod; id_y_term; id_y_cons];
-                gen_gtbfterm [id_abs; id_y_term];
-                gen_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
+                make_gtbfterm [id_minus_op; id_y_term];
+                make_gtbfterm [id_plus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_minus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_mul_op; id_y_cons; id_y_term];
+                make_gtbfterm [id_mul_op; id_y_term; id_y_cons];
+                make_gtbfterm [id_div; id_y_term; id_y_cons];
+                make_gtbfterm [id_mod; id_y_term; id_y_cons];
+                make_gtbfterm [id_abs; id_y_term];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
               ]
             )
         );
@@ -130,11 +146,11 @@ let dom_LIA_grammardef : string -> Ast.grammar_def =
               y_pred,
               sortBool,
               [
-                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_le_op; id_y_term; id_y_term];
+                make_gtbfterm [id_eq_op; id_y_term; id_y_term];
+                make_gtbfterm [id_gt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_ge_op; id_y_term; id_y_term];
+                make_gtbfterm [id_lt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_le_op; id_y_term; id_y_term];
               ]
             )
         )
@@ -153,9 +169,8 @@ let dom_LIA_grammardef : string -> Ast.grammar_def =
 
 let dom_NIA_grammardef : string -> Ast.grammar_def =
   fun prefix ->
-  let pre : string = prefix ^ "NIA_" in
-  let y_term : Ast.symbol = Symbol (pre ^ "y_term") in
-  let y_pred : Ast.symbol = Symbol (pre ^ "y_pred") in
+  let y_term : Ast.symbol = make_y_term_int prefix in
+  let y_pred : Ast.symbol = make_y_pred_bool prefix in
   let id_y_term : Ast.identifier = SymbolIdentifier y_term in
   let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
   (
@@ -170,14 +185,14 @@ let dom_NIA_grammardef : string -> Ast.grammar_def =
               [
                 GTConstant sortInt;
                 GTVariable sortInt;
-                gen_gtbfterm [id_minus_op; id_y_term];
-                gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_mul_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_div; id_y_term; id_y_term];
-                gen_gtbfterm [id_mod; id_y_term; id_y_term];
-                gen_gtbfterm [id_abs; id_y_term];
-                gen_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
+                make_gtbfterm [id_minus_op; id_y_term];
+                make_gtbfterm [id_plus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_minus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_mul_op; id_y_term; id_y_term];
+                make_gtbfterm [id_div; id_y_term; id_y_term];
+                make_gtbfterm [id_mod; id_y_term; id_y_term];
+                make_gtbfterm [id_abs; id_y_term];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
               ]
             )
         );
@@ -188,11 +203,11 @@ let dom_NIA_grammardef : string -> Ast.grammar_def =
               y_pred,
               sortBool,
               [
-                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_le_op; id_y_term; id_y_term];
+                make_gtbfterm [id_eq_op; id_y_term; id_y_term];
+                make_gtbfterm [id_gt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_ge_op; id_y_term; id_y_term];
+                make_gtbfterm [id_lt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_le_op; id_y_term; id_y_term];
               ]
             )
         )
@@ -211,10 +226,9 @@ let dom_NIA_grammardef : string -> Ast.grammar_def =
 
 let dom_LRA_grammardef : string -> Ast.grammar_def =
   fun prefix ->
-  let pre : string = prefix ^ "LRA_" in
-  let y_term : Ast.symbol = Symbol (pre ^ "y_term") in
-  let y_cons : Ast.symbol = Symbol (pre ^ "y_cons") in
-  let y_pred : Ast.symbol = Symbol (pre ^ "y_pred") in
+  let y_term : Ast.symbol = make_y_term_real prefix in
+  let y_cons : Ast.symbol = make_y_cons_real prefix in
+  let y_pred : Ast.symbol = make_y_pred_bool prefix in
   let id_y_term : Ast.identifier = SymbolIdentifier y_term in
   let id_y_cons : Ast.identifier = SymbolIdentifier y_cons in
   let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
@@ -230,12 +244,12 @@ let dom_LRA_grammardef : string -> Ast.grammar_def =
               [
                 GTBfTerm (BfIdentifier id_y_cons);
                 GTVariable sortReal;
-                gen_gtbfterm [id_minus_op; id_y_term];
-                gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_mul_op; id_y_cons; id_y_term];
-                gen_gtbfterm [id_mul_op; id_y_term; id_y_cons];
-                gen_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
+                make_gtbfterm [id_minus_op; id_y_term];
+                make_gtbfterm [id_plus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_minus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_mul_op; id_y_cons; id_y_term];
+                make_gtbfterm [id_mul_op; id_y_term; id_y_cons];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
               ]
             )
         );
@@ -255,11 +269,11 @@ let dom_LRA_grammardef : string -> Ast.grammar_def =
               y_pred,
               sortBool,
               [
-                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_le_op; id_y_term; id_y_term];
+                make_gtbfterm [id_eq_op; id_y_term; id_y_term];
+                make_gtbfterm [id_gt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_ge_op; id_y_term; id_y_term];
+                make_gtbfterm [id_lt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_le_op; id_y_term; id_y_term];
               ]
             )
         )
@@ -279,9 +293,8 @@ let dom_LRA_grammardef : string -> Ast.grammar_def =
 
 let dom_NRA_grammardef : string -> Ast.grammar_def =
   fun prefix ->
-  let pre : string = prefix ^ "NRA_" in
-  let y_term : Ast.symbol = Symbol (pre ^ "y_term") in
-  let y_pred : Ast.symbol = Symbol (pre ^ "y_pred") in
+  let y_term : Ast.symbol = make_y_term_real prefix in
+  let y_pred : Ast.symbol = make_y_pred_bool prefix in
   let id_y_term : Ast.identifier = SymbolIdentifier y_term in
   let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
   (
@@ -296,12 +309,12 @@ let dom_NRA_grammardef : string -> Ast.grammar_def =
               [
                 GTConstant sortReal;
                 GTVariable sortReal;
-                gen_gtbfterm [id_minus_op; id_y_term];
-                gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_mul_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_div_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
+                make_gtbfterm [id_minus_op; id_y_term];
+                make_gtbfterm [id_plus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_minus_op; id_y_term; id_y_term];
+                make_gtbfterm [id_mul_op; id_y_term; id_y_term];
+                make_gtbfterm [id_div_op; id_y_term; id_y_term];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
               ]
             )
         );
@@ -312,11 +325,165 @@ let dom_NRA_grammardef : string -> Ast.grammar_def =
               y_pred,
               sortBool,
               [
-                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
-                gen_gtbfterm [id_le_op; id_y_term; id_y_term];
+                make_gtbfterm [id_eq_op; id_y_term; id_y_term];
+                make_gtbfterm [id_gt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_ge_op; id_y_term; id_y_term];
+                make_gtbfterm [id_lt_op; id_y_term; id_y_term];
+                make_gtbfterm [id_le_op; id_y_term; id_y_term];
+              ]
+            )
+        )
+      ]
+  )
+
+
+
+
+
+(**********************************************************)
+(**********************************************************)
+(************************** BV ****************************)
+(**********************************************************)
+(**********************************************************)
+
+let dom_BV_grammardef : string -> Ast.grammar_def =
+  fun prefix ->
+  let y_term : Ast.symbol = make_y_term_bv32 prefix in
+  let y_pred : Ast.symbol = make_y_pred_bool prefix in
+  let id_y_term : Ast.identifier = SymbolIdentifier y_term in
+  let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
+  let id_bvnot  : Ast.identifier = make_id "bvnot"   in
+  let id_bvand  : Ast.identifier = make_id "bvand"   in
+  let id_bvor   : Ast.identifier = make_id "bvor"    in
+  let id_bvneg  : Ast.identifier = make_id "bvneg"   in
+  let id_bvadd  : Ast.identifier = make_id "bvadd"   in
+  let id_bvmul  : Ast.identifier = make_id "bvmul"   in
+  let id_bvudiv : Ast.identifier = make_id "bvudiv"  in
+  let id_bvurem : Ast.identifier = make_id "bvurem"  in
+  let id_bvshl  : Ast.identifier = make_id "bvshl"   in
+  let id_bvlshr : Ast.identifier = make_id "bvlshr"  in
+  let id_bvult  : Ast.identifier = make_id "bvult"   in
+  let sortBV32  : Ast.sort = Sort (UnderbarIdentifier (Symbol ("BitVec"), [NumeralIndex "32"])) in
+  (
+    GrammarDef
+      [
+        (
+          SortedVar (y_term, sortBV32),
+          GroupedRuleList
+            (
+              y_term, 
+              sortBV32, 
+              [
+                GTConstant sortBV32;
+                GTVariable sortBV32;
+                make_gtbfterm [id_bvnot; id_y_term];
+                make_gtbfterm [id_bvand; id_y_term; id_y_term];
+                make_gtbfterm [id_bvor; id_y_term; id_y_term];
+                make_gtbfterm [id_bvneg; id_y_term];
+                make_gtbfterm [id_bvadd; id_y_term; id_y_term];
+                make_gtbfterm [id_bvmul; id_y_term; id_y_term];
+                make_gtbfterm [id_bvudiv; id_y_term; id_y_term];
+                make_gtbfterm [id_bvurem; id_y_term; id_y_term];
+                make_gtbfterm [id_bvshl; id_y_term; id_y_term];
+                make_gtbfterm [id_bvlshr; id_y_term; id_y_term];
+                make_gtbfterm [id_bvult; id_y_term; id_y_term];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term];
+              ]
+            )
+        );
+        (
+          SortedVar (y_pred, sortBool),
+          GroupedRuleList
+            (
+              y_pred,
+              sortBool,
+              [
+                make_gtbfterm [id_bvult; id_y_term; id_y_term];
+              ]
+            )
+        )
+      ]
+  )
+
+
+
+
+
+(**********************************************************)
+(**********************************************************)
+(*************************** S ****************************)
+(**********************************************************)
+(**********************************************************)
+
+let dom_S_grammardef : string -> Ast.grammar_def =
+  fun prefix ->
+  let y_term_str : Ast.symbol = make_y_term_string prefix in
+  let y_term_int : Ast.symbol = make_y_term_int prefix in
+  let y_pred : Ast.symbol = make_y_pred_bool prefix in
+  let id_y_term_str : Ast.identifier = SymbolIdentifier y_term_str in
+  let id_y_term_int : Ast.identifier = SymbolIdentifier y_term_int in
+  let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
+  let id_strpp_op     : Ast.identifier = make_id "str.++" in
+  let id_strat        : Ast.identifier = make_id "str.at" in
+  let id_strsubstr    : Ast.identifier = make_id "str.substr" in
+  let id_strindexof   : Ast.identifier = make_id "str.indexof" in
+  let id_strreplace   : Ast.identifier = make_id "str.replace" in
+  let id_strfromint   : Ast.identifier = make_id "str.from-int" in
+  let id_strlen       : Ast.identifier = make_id "str.len" in
+  let id_strtoint     : Ast.identifier = make_id "str.to-int" in
+  let id_strcontains  : Ast.identifier = make_id "str.contains" in
+  let id_strprefixof  : Ast.identifier = make_id "str.prefixof" in
+  let id_strsuffixof  : Ast.identifier = make_id "str.suffixof" in 
+  let id_strlt        : Ast.identifier = make_id "str.<" in 
+  let id_strle        : Ast.identifier = make_id "str.<=" in 
+  (
+    GrammarDef
+      [
+        (
+          SortedVar (y_term_str, sortString),
+          GroupedRuleList
+            (
+              y_term_str, 
+              sortString, 
+              [
+                GTConstant sortString;
+                GTVariable sortString;
+                make_gtbfterm [id_strpp_op; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strat; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strsubstr; id_y_term_str; id_y_term_int; id_y_term_int];
+                make_gtbfterm [id_strindexof; id_y_term_str; id_y_term_str; id_y_term_int];
+                make_gtbfterm [id_strreplace; id_y_term_str; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strfromint; id_y_term_int];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term_str; id_y_term_str]
+              ]
+            )
+        );
+        (
+          SortedVar (y_term_int, sortInt),
+          GroupedRuleList
+            (
+              y_term_int,
+              sortInt,
+              [
+                GTVariable sortInt;
+                make_gtbfterm [id_strlen; id_y_term_str];
+                make_gtbfterm [id_strtoint; id_y_term_str];
+                make_gtbfterm [id_ite; id_y_pred; id_y_term_int; id_y_term_int]
+              ]
+            )
+        );
+        (
+          SortedVar (y_pred, sortBool),
+          GroupedRuleList
+            (
+              y_pred,
+              sortBool,
+              [
+                make_gtbfterm [id_strcontains; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strprefixof; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strsuffixof; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strlt; id_y_term_str; id_y_term_str];
+                make_gtbfterm [id_strle; id_y_term_str; id_y_term_str];
               ]
             )
         )

--- a/src/solver/domainGrammar.ml
+++ b/src/solver/domainGrammar.ml
@@ -38,10 +38,12 @@ let sortReal    : Ast.sort = gen_short_sort "Real"
 let id_plus_op  : Ast.identifier = gen_id "+"
 let id_minus_op : Ast.identifier = gen_id "-"
 let id_mul_op   : Ast.identifier = gen_id "*"
+let id_div_op   : Ast.identifier = gen_id "/"
 let id_div      : Ast.identifier = gen_id "div"
 let id_mod      : Ast.identifier = gen_id "mod"
 let id_abs      : Ast.identifier = gen_id "abs"
 let id_ite      : Ast.identifier = gen_id "ite"
+let id_eq_op    : Ast.identifier = gen_id "="
 let id_gt_op    : Ast.identifier = gen_id ">"
 let id_ge_op    : Ast.identifier = gen_id ">="
 let id_lt_op    : Ast.identifier = gen_id "<"
@@ -64,7 +66,13 @@ let gen_gtbfterm : Ast.identifier list -> Ast.gterm =
 
 
 
+
+
 (****** Domain Grammars ******)
+(* grammar version : 2019.Jun.30 *)
+
+
+
 
 
 (**********************************************************)
@@ -93,7 +101,7 @@ let dom_LIA_grammardef : string -> Ast.grammar_def =
               sortInt, 
               [
                 GTBfTerm (BfIdentifier id_y_cons);
-                GTVariable (sortInt);
+                GTVariable sortInt;
                 gen_gtbfterm [id_minus_op; id_y_term];
                 gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
@@ -122,6 +130,7 @@ let dom_LIA_grammardef : string -> Ast.grammar_def =
               y_pred,
               sortBool,
               [
+                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
@@ -131,6 +140,9 @@ let dom_LIA_grammardef : string -> Ast.grammar_def =
         )
       ]
   )
+
+
+
 
 
 (**********************************************************)
@@ -156,7 +168,7 @@ let dom_NIA_grammardef : string -> Ast.grammar_def =
               y_term, 
               sortInt, 
               [
-                GTConstant sortReal;
+                GTConstant sortInt;
                 GTVariable sortInt;
                 gen_gtbfterm [id_minus_op; id_y_term];
                 gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
@@ -176,6 +188,131 @@ let dom_NIA_grammardef : string -> Ast.grammar_def =
               y_pred,
               sortBool,
               [
+                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_le_op; id_y_term; id_y_term];
+              ]
+            )
+        )
+      ]
+  )
+
+
+
+
+
+(**********************************************************)
+(**********************************************************)
+(************************* LRA ****************************)
+(**********************************************************)
+(**********************************************************)
+
+let dom_LRA_grammardef : string -> Ast.grammar_def =
+  fun prefix ->
+  let pre : string = prefix ^ "LRA_" in
+  let y_term : Ast.symbol = Symbol (pre ^ "y_term") in
+  let y_cons : Ast.symbol = Symbol (pre ^ "y_cons") in
+  let y_pred : Ast.symbol = Symbol (pre ^ "y_pred") in
+  let id_y_term : Ast.identifier = SymbolIdentifier y_term in
+  let id_y_cons : Ast.identifier = SymbolIdentifier y_cons in
+  let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
+  (
+    GrammarDef
+      [
+        (
+          SortedVar (y_term, sortReal),
+          GroupedRuleList
+            (
+              y_term, 
+              sortReal, 
+              [
+                GTBfTerm (BfIdentifier id_y_cons);
+                GTVariable sortReal;
+                gen_gtbfterm [id_minus_op; id_y_term];
+                gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_mul_op; id_y_cons; id_y_term];
+                gen_gtbfterm [id_mul_op; id_y_term; id_y_cons];
+                gen_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
+              ]
+            )
+        );
+        (
+          SortedVar (y_cons, sortReal),
+          GroupedRuleList
+            (
+              y_cons,
+              sortReal,
+              [ GTConstant sortReal ]
+            )
+        );
+        (
+          SortedVar (y_pred, sortBool),
+          GroupedRuleList
+            (
+              y_pred,
+              sortBool,
+              [
+                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_lt_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_le_op; id_y_term; id_y_term];
+              ]
+            )
+        )
+      ]
+  )
+
+
+
+(**********************************************************)
+(**********************************************************)
+(************************* NRA ****************************)
+(**********************************************************)
+(**********************************************************)
+(* NOTICE: In 19.Jun.30 version, NRA-grammar mentions 'y_cons' symbol but it doesn't have any derivative rule.
+    So I reomved it in this code.
+*)
+
+let dom_NRA_grammardef : string -> Ast.grammar_def =
+  fun prefix ->
+  let pre : string = prefix ^ "NRA_" in
+  let y_term : Ast.symbol = Symbol (pre ^ "y_term") in
+  let y_pred : Ast.symbol = Symbol (pre ^ "y_pred") in
+  let id_y_term : Ast.identifier = SymbolIdentifier y_term in
+  let id_y_pred : Ast.identifier = SymbolIdentifier y_pred in
+  (
+    GrammarDef
+      [
+        (
+          SortedVar (y_term, sortReal),
+          GroupedRuleList
+            (
+              y_term, 
+              sortReal, 
+              [
+                GTConstant sortReal;
+                GTVariable sortReal;
+                gen_gtbfterm [id_minus_op; id_y_term];
+                gen_gtbfterm [id_plus_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_minus_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_mul_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_div_op; id_y_term; id_y_term];
+                gen_gtbfterm [id_ite; id_y_pred; id_y_term; id_y_term]
+              ]
+            )
+        );
+        (
+          SortedVar (y_pred, sortBool),
+          GroupedRuleList
+            (
+              y_pred,
+              sortBool,
+              [
+                gen_gtbfterm [id_eq_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_gt_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_ge_op; id_y_term; id_y_term];
                 gen_gtbfterm [id_lt_op; id_y_term; id_y_term];

--- a/src/solver/preprocessor.ml
+++ b/src/solver/preprocessor.ml
@@ -159,25 +159,7 @@ if other sort like this is about to enter signature, we need to reject this.
 *)
 let checkBVsort sign = 
   match sign with
-  | SortSignature s -> (
-      match s with
-      | Sort next -> (
-          match next with
-          | UnderbarIdentifier (sb, li) -> (
-              match sb with
-              | Symbol "BitVec" -> (
-                  match li with
-                  | h::t -> (
-                      match t with
-                      | [] -> (
-                          match h with
-                          | NumeralIndex _ -> true
-                          | _ -> false )
-                      | _ -> false )
-                  | _ -> false )
-              | _ -> false )
-          | _ -> false )
-      | _ -> false )
+  | SortSignature (Sort (UnderbarIdentifier (Symbol "BitVec", ((NumeralIndex _ ):: [])))) -> true
   | _ -> false
 
 let rec isBVinSignature li =

--- a/src/utils/listMethods.ml
+++ b/src/utils/listMethods.ml
@@ -11,3 +11,13 @@ let rec containAnyElement li eli =
   | h::t ->
     if containElement li h then true
     else containAnyElement li t      
+
+let rec containValid li cond =
+  match li with
+  | [] -> false
+  | h :: t -> if cond h then true else containValid t cond
+
+(* slightly different with List.map *)
+let rec collectAppliedList : ('a -> 'b list) -> 'a list -> 'b list =
+  fun applyfunction targetlist ->
+  List.fold_left (fun collectlist targetelement -> (applyfunction targetelement) @ collectlist) [] targetlist

--- a/src/utils/stringMethods.ml
+++ b/src/utils/stringMethods.ml
@@ -15,3 +15,12 @@ let isPrefixDuplicated : string -> string list -> bool =
   fun prefix strlist ->
   let slicedList = prefixSlicing (String.length prefix) strlist in
   ListMethods.containValid slicedList (String.equal prefix)
+
+let strListMiddlePaddingMap : string -> string list -> string list =
+  fun paddingstr slist ->
+  match slist with
+  | [] -> slist
+  | h :: [] -> slist
+  | h :: t -> let tt = (List.map (fun s -> paddingstr ^ s) t) in (h :: tt)
+
+let strListWsMiddlePadding = strListMiddlePaddingMap " "

--- a/src/utils/stringMethods.ml
+++ b/src/utils/stringMethods.ml
@@ -1,0 +1,17 @@
+(*
+  prefixSlicing filter and return prefixes for given length.
+    example INPUT: prefixSlicing 3 ['a'; 'bc'; 'def'; 'ghij'; 'klmno'; 'pqrstuv']
+    exapmle OUTPUT: ['def'; 'ghi'; 'klm'; 'pqr']
+*)
+let prefixSlicing : int -> string list -> string list =
+  fun n strlist ->
+  let filteredlist = List.filter (fun s -> String.length(s) >= n) strlist in
+  List.map (fun s -> String.sub s 0 n) filteredlist
+
+(*
+  isPrefixDuplicated checks whether given prefix appears at least once at given string list.
+*)
+let isPrefixDuplicated : string -> string list -> bool =
+  fun prefix strlist ->
+  let slicedList = prefixSlicing (String.length prefix) strlist in
+  ListMethods.containValid slicedList (String.equal prefix)

--- a/src/utils/typeMethods.ml
+++ b/src/utils/typeMethods.ml
@@ -1,0 +1,130 @@
+open Ast
+
+(*
+  Collect strings (numeral, boolconst, identifiers, ...) from Ast type argument.
+*)
+
+
+(*
+  <<string base>>
+  numeral : string
+  boolconst : string
+*)
+
+(*
+LIST
+
+cmd
+smt_cmd
+* term
+* bf_term
+* sorted_var
+* var_binding
+* identifier
+* symbol
+* index
+* sort
+-- feature
+*sort_decl
+* dt_dec
+* dt_cond_dec
+grammar_def
+grouped_rule_list
+gterm
+* literal
+* numeral
+* boolconst
+
+*)
+
+let literal_gets : Ast.literal -> string =
+  fun lit ->
+  match lit with
+  | Numeral n -> n
+  | Decimal d -> d
+  | BoolConst bc -> bc
+  | HexConst hc -> hc
+  | BinConst bc -> bc
+  | StringConst sc -> sc
+
+let symbol_gets : Ast.symbol -> string = 
+  fun (Symbol s) -> s
+
+let index_gets : Ast.index -> string = 
+  fun ind ->
+  match ind with
+  | NumeralIndex ni -> ni
+  | SymbolIndex si -> symbol_gets si
+
+let identifier_getsl : Ast.identifier -> string list =
+  fun id ->
+  match id with
+  | SymbolIdentifier si -> [symbol_gets si]
+  | UnderbarIdentifier (si, ilist) -> (symbol_gets si) :: (List.map index_gets ilist)
+
+let rec sort_getsl : Ast.sort -> string list =
+  fun s ->
+  match s with
+  | Sort id -> identifier_getsl id
+  | SortWithSorts (id, sl)
+    -> (identifier_getsl id) @ (sortlist_getsl sl)
+and sortlist_getsl : Ast.sort list -> string list =
+  fun sortlist -> ListMethods.collectAppliedList sort_getsl sortlist
+
+let sorted_var_getsl : Ast.sorted_var -> string list =
+  fun (SortedVar (sym, srt)) -> (symbol_gets sym) :: (sort_getsl srt)
+
+let sort_decl_getsl : Ast.sort_decl -> string list =
+  fun (SortDeclaration (sym, num)) -> [symbol_gets sym; num]
+
+let rec term_getsl : Ast.term -> string list =
+  fun t ->
+  match t with
+  | Identifier id -> identifier_getsl id
+  | Literal li -> [literal_gets li]
+  | IdentifierTerms (id, tlist) -> (identifier_getsl id) @ (termlist_getsl tlist)
+  | Exists (svlist, t) ->
+    (ListMethods.collectAppliedList sorted_var_getsl svlist) @ (term_getsl t)
+  | Forall (svlist, t) ->
+    (ListMethods.collectAppliedList sorted_var_getsl svlist) @ (term_getsl t)
+  | Let (vblist, t) ->
+    (ListMethods.collectAppliedList var_binding_getsl vblist) @ (term_getsl t)
+and termlist_getsl : Ast.term list -> string list =
+  fun termlist -> ListMethods.collectAppliedList term_getsl termlist
+and var_binding_getsl : Ast.var_binding -> string list =
+  fun (VarBinding (sym, t)) -> (symbol_gets sym) :: (term_getsl t)
+
+let rec bf_term_getsl : Ast.bf_term -> string list =
+  fun bft ->
+  match bft with
+  | BfIdentifier id -> identifier_getsl id
+  | BfLiteral li -> [literal_gets li]
+  | BfIdentifierTerms (id, bftlist) -> (identifier_getsl id) @ (bf_termlist_getsl bftlist)
+and bf_termlist_getsl : Ast.bf_term list -> string list =
+  fun bftermlist -> ListMethods.collectAppliedList bf_term_getsl bftermlist
+
+let dt_cond_dec_getsl : Ast.dt_cond_dec -> string list =
+  fun (DTConsDec (sym, svlist)) ->
+  (symbol_gets sym) :: (ListMethods.collectAppliedList sorted_var_getsl svlist)
+
+let dt_dec_getsl : Ast.dt_dec -> string list =
+  fun (DTDec dcdlist) -> ListMethods.collectAppliedList dt_cond_dec_getsl dcdlist
+
+let gterm_getsl : Ast.gterm -> string list =
+  fun gt ->
+  match gt with
+  | GTConstant s -> sort_getsl s
+  | GTVariable s -> sort_getsl s
+  | GTBfTerm bft -> bf_term_getsl bft
+
+let grouped_rule_list_getsl : Ast.grouped_rule_list -> string list =
+  fun (GroupedRuleList (sym, s, glist)) ->
+  [symbol_gets sym] @ (sort_getsl s) @ (ListMethods.collectAppliedList gterm_getsl glist)
+
+let grammar_def_getsl : Ast.grammar_def -> string list =
+  fun (GrammarDef pair_list) ->
+  let pair_getsl : (Ast.sorted_var * grouped_rule_list) -> string list =
+    fun (sv, grl) -> (sorted_var_getsl sv) @ (grouped_rule_list_getsl grl)
+  in
+  ListMethods.collectAppliedList pair_getsl pair_list
+

--- a/src/utils/typeMethods.ml
+++ b/src/utils/typeMethods.ml
@@ -2,40 +2,10 @@ open Ast
 
 (*
   Collect strings (numeral, boolconst, identifiers, ...) from Ast type argument.
+  Unlike solver/stringfier.ml, It extracts only non-predefined strings.
 *)
 
-
-(*
-  <<string base>>
-  numeral : string
-  boolconst : string
-*)
-
-(*
-LIST
-
-cmd
-smt_cmd
-* term
-* bf_term
-* sorted_var
-* var_binding
-* identifier
-* symbol
-* index
-* sort
--- feature
-*sort_decl
-* dt_dec
-* dt_cond_dec
-grammar_def
-grouped_rule_list
-gterm
-* literal
-* numeral
-* boolconst
-
-*)
+let feature_getsl : Ast.feature -> string list = fun f -> []
 
 let literal_gets : Ast.literal -> string =
   fun lit ->
@@ -73,6 +43,9 @@ and sortlist_getsl : Ast.sort list -> string list =
 
 let sorted_var_getsl : Ast.sorted_var -> string list =
   fun (SortedVar (sym, srt)) -> (symbol_gets sym) :: (sort_getsl srt)
+let sorted_varlist_getsl : Ast.sorted_var list -> string list =
+  fun svlist ->
+  ListMethods.collectAppliedList sorted_var_getsl svlist
 
 let sort_decl_getsl : Ast.sort_decl -> string list =
   fun (SortDeclaration (sym, num)) -> [symbol_gets sym; num]
@@ -84,9 +57,9 @@ let rec term_getsl : Ast.term -> string list =
   | Literal li -> [literal_gets li]
   | IdentifierTerms (id, tlist) -> (identifier_getsl id) @ (termlist_getsl tlist)
   | Exists (svlist, t) ->
-    (ListMethods.collectAppliedList sorted_var_getsl svlist) @ (term_getsl t)
+    (sorted_varlist_getsl svlist) @ (term_getsl t)
   | Forall (svlist, t) ->
-    (ListMethods.collectAppliedList sorted_var_getsl svlist) @ (term_getsl t)
+    (sorted_varlist_getsl svlist) @ (term_getsl t)
   | Let (vblist, t) ->
     (ListMethods.collectAppliedList var_binding_getsl vblist) @ (term_getsl t)
 and termlist_getsl : Ast.term list -> string list =
@@ -105,7 +78,7 @@ and bf_termlist_getsl : Ast.bf_term list -> string list =
 
 let dt_cond_dec_getsl : Ast.dt_cond_dec -> string list =
   fun (DTConsDec (sym, svlist)) ->
-  (symbol_gets sym) :: (ListMethods.collectAppliedList sorted_var_getsl svlist)
+  (symbol_gets sym) :: (sorted_varlist_getsl svlist)
 
 let dt_dec_getsl : Ast.dt_dec -> string list =
   fun (DTDec dcdlist) -> ListMethods.collectAppliedList dt_cond_dec_getsl dcdlist
@@ -128,3 +101,35 @@ let grammar_def_getsl : Ast.grammar_def -> string list =
   in
   ListMethods.collectAppliedList pair_getsl pair_list
 
+let smt_cmd_getsl : Ast.smt_cmd -> string list = 
+  fun sc ->
+  match sc with
+  | DeclareDatatype (sym, dtdec) -> (symbol_gets sym) :: (dt_dec_getsl dtdec)
+  | DeclareDatatypes [] -> []
+  | DeclareDatatypes pairlist ->
+    ListMethods.collectAppliedList (fun (sdecl, dtdec) -> (sort_decl_getsl sdecl) @ (dt_dec_getsl dtdec)) pairlist
+  | DeclareSort (sym, num) -> [(symbol_gets sym); num]
+  | DefineFun (sym, svlist, srt, t) -> 
+    [symbol_gets sym] @ (sorted_varlist_getsl svlist) @ (sort_getsl srt) @ (term_getsl t)
+  | DefineSort (sym, srt) -> (symbol_gets sym) :: (sort_getsl srt)
+  | SetLogic sym -> [symbol_gets sym]
+  | SetOption (sym, lit) -> [(symbol_gets sym); (literal_gets lit)]
+
+let cmd_getsl : Ast.cmd -> string list =
+  fun c ->
+  match c with
+  | CheckSynth -> []
+  | Constraint t -> term_getsl t
+  | DeclareVar (sym, srt) -> (symbol_gets sym) :: (sort_getsl srt)
+  | InvConstraint (sym1, sym2, sym3, sym4) ->
+    [symbol_gets sym1; symbol_gets sym2; symbol_gets sym3; symbol_gets sym4]
+  | SetFeature (f, bc) -> (bc) :: (feature_getsl f)
+  | SynthFun (sym, svlist, srt, None) ->
+    [symbol_gets sym] @ (sorted_varlist_getsl svlist) @ (sort_getsl srt)
+  | SynthFun (sym, svlist, srt, Some (gramdef)) ->
+    [symbol_gets sym] @ (sorted_varlist_getsl svlist) @ (sort_getsl srt) @ (grammar_def_getsl gramdef)
+  | SynthInv (sym, svlist, None) -> 
+    (symbol_gets sym) :: (sorted_varlist_getsl svlist)
+  | SynthInv (sym, svlist, Some (gramdef)) -> 
+    [symbol_gets sym] @ (sorted_varlist_getsl svlist) @ (grammar_def_getsl gramdef)
+  | SmtCmd sc -> smt_cmd_getsl sc


### PR DESCRIPTION
#12 문제를 가장 간단한 방법으로 해결했다.

SyGuS 문제에 grammar가 아예 주어지지 않은 경우, [SyGuS Doc](https://sygus.org/assets/pdf/SyGuS-IF_2.0.pdf) (2019.06.30 ver.) Appendix-B 에 쓰여진 문법 중 logic에 맞춰 문법을 넣어준다. 

전체 프로세스로 보자면 Preprocessor.preprocess에서 이 작업을 통해 모든 문법이 없는 synth-fun 문장들에 대해 문법을 추가하는 모습이다.